### PR TITLE
Fix bind implementation and enhance select-and-replace tests

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "playwright test",
     "test:ui": "playwright test --ui",
+    "test:firefox": "playwright test --config=playwright.firefox.config.ts",
     "dev": "vite"
   },
   "devDependencies": {

--- a/e2e/playwright.firefox.config.ts
+++ b/e2e/playwright.firefox.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test'
+import baseConfig from './playwright.config'
+
+// Separate config so `npx playwright test` (the default, run by every
+// contributor) doesn't suddenly require the Firefox binary. Run this one
+// explicitly with `npm run test:firefox` (needs `npx playwright install
+// firefox` once). Firefox is where the select-and-replace race in
+// `select-replace-race.spec.ts` was originally found and reproduced — see
+// that file's header comment for the full story.
+export default defineConfig({
+  ...baseConfig,
+  projects: [
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+  ],
+})

--- a/e2e/tests/select-replace-race.spec.ts
+++ b/e2e/tests/select-replace-race.spec.ts
@@ -1,0 +1,251 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Regression coverage for a real-Firefox bug: select all text in a field,
+ * then type over it. The `keydown` + `requestAnimationFrame` fallback frame
+ * (see `onKey` in `bind.ts`/`bind-decimal.ts`) can fire *before* the browser
+ * has actually applied the keystroke's default action — at that point
+ * `target.value` is still unchanged and the selection is still the full
+ * pre-edit range, not a post-edit collapsed caret. The library used to
+ * blindly reformat and collapse that range, so the browser's own pending
+ * replace-selection edit landed on a collapsed caret instead — dropping or
+ * corrupting the keystroke instead of replacing the selection.
+ *
+ * Deterministic tests below dispatch only `keydown` (never `input`) with the
+ * selection still spanning a real range, exactly what a premature frame
+ * observes in the real bug — no reliance on winning or losing a real timing
+ * race. A best-effort real-keyboard test at the end exercises the actual
+ * event pipeline end to end.
+ */
+
+async function freshMaskedInput(
+  page: Page,
+  mask: string | string[],
+  initialValue: string,
+  options?: { segmented?: boolean },
+): Promise<void> {
+  await page.evaluate(
+    ({ mask, initialValue, options }) => {
+      const old = document.querySelector('#race-input')
+      if (old) old.remove()
+      const input = document.createElement('input')
+      input.id = 'race-input'
+      document.body.appendChild(input)
+      window.motherMask.bind(input, mask, options ?? null)
+      input.value = initialValue
+      ;(window as unknown as { __changeCount: number }).__changeCount = 0
+    },
+    { mask, initialValue, options },
+  )
+}
+
+async function freshDecimalInput(
+  page: Page,
+  decimalOptions: Record<string, unknown>,
+  initialValue: string,
+): Promise<void> {
+  await page.evaluate(
+    ({ decimalOptions, initialValue }) => {
+      const old = document.querySelector('#race-input')
+      if (old) old.remove()
+      const input = document.createElement('input')
+      input.id = 'race-input'
+      document.body.appendChild(input)
+      window.motherMask.bindDecimal(input, decimalOptions)
+      input.value = initialValue
+    },
+    { decimalOptions, initialValue },
+  )
+}
+
+/** Dispatch a real `keydown` on `#race-input` without simulating the browser's default action. */
+async function dispatchPrematureKeydown(
+  page: Page,
+  init: { key: string; ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean; altKey?: boolean },
+): Promise<void> {
+  await page.evaluate((init) => {
+    const input = document.querySelector<HTMLInputElement>('#race-input')!
+    input.focus()
+    const ev = new KeyboardEvent('keydown', { ...init, bubbles: true, cancelable: true })
+    input.dispatchEvent(ev)
+  }, init)
+}
+
+async function selectionAndValue(page: Page): Promise<{ start: number; end: number; value: string }> {
+  return page.evaluate(() => {
+    const input = document.querySelector<HTMLInputElement>('#race-input')!
+    return { start: input.selectionStart ?? -1, end: input.selectionEnd ?? -1, value: input.value }
+  })
+}
+
+async function waitAnimationFrames(page: Page, times = 3): Promise<void> {
+  await page.evaluate(async (times) => {
+    for (let i = 0; i < times; i++) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+    }
+  }, times)
+}
+
+test.describe('select-and-replace race: keydown fallback frame vs. browser default action (bind)', () => {
+  test('character insert: selection is not collapsed while the edit has not landed', async ({ page }) => {
+    await page.goto('/')
+    await freshMaskedInput(page, '999.999.999-99', '098.098.098-08')
+    await page.evaluate(() => {
+      const input = document.querySelector<HTMLInputElement>('#race-input')!
+      input.setSelectionRange(0, 14)
+    })
+    await dispatchPrematureKeydown(page, { key: '0' })
+    await waitAnimationFrames(page)
+
+    const state = await selectionAndValue(page)
+    expect(state).toEqual({ start: 0, end: 14, value: '098.098.098-08' })
+  })
+
+  test('Backspace: a real selection range is left untouched while the edit has not landed', async ({ page }) => {
+    await page.goto('/')
+    await freshMaskedInput(page, '999-999', '123-456')
+    await page.evaluate(() => document.querySelector<HTMLInputElement>('#race-input')!.setSelectionRange(1, 5))
+    await dispatchPrematureKeydown(page, { key: 'Backspace' })
+    await waitAnimationFrames(page)
+
+    const state = await selectionAndValue(page)
+    expect(state).toEqual({ start: 1, end: 5, value: '123-456' })
+  })
+
+  test('Delete: a real selection range is left untouched while the edit has not landed', async ({ page }) => {
+    await page.goto('/')
+    await freshMaskedInput(page, '999-999', '123-456')
+    await page.evaluate(() => document.querySelector<HTMLInputElement>('#race-input')!.setSelectionRange(2, 6))
+    await dispatchPrematureKeydown(page, { key: 'Delete' })
+    await waitAnimationFrames(page)
+
+    const state = await selectionAndValue(page)
+    expect(state).toEqual({ start: 2, end: 6, value: '123-456' })
+  })
+
+  test('array mask (mask-switching pattern): selection survives a premature frame', async ({ page }) => {
+    await page.goto('/')
+    await freshMaskedInput(page, ['(99) 9999-9999', '(99) 99999-9999'], '(11) 99988-7766')
+    await page.evaluate(() => document.querySelector<HTMLInputElement>('#race-input')!.setSelectionRange(0, 15))
+    await dispatchPrematureKeydown(page, { key: '5' })
+    await waitAnimationFrames(page)
+
+    const state = await selectionAndValue(page)
+    expect(state).toEqual({ start: 0, end: 15, value: '(11) 99988-7766' })
+  })
+
+  test('recovers correctly once the browser applies the edit and fires `input`, even after the frame bailed', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await freshMaskedInput(page, '999.999.999-99', '098.098.098-08')
+    await page.evaluate(() => document.querySelector<HTMLInputElement>('#race-input')!.setSelectionRange(0, 14))
+    await dispatchPrematureKeydown(page, { key: '0' })
+    await waitAnimationFrames(page)
+    // Selection must still be the full range — the frame bailed.
+    expect(await selectionAndValue(page)).toEqual({ start: 0, end: 14, value: '098.098.098-08' })
+
+    // Browser now (slightly late) applies the actual edit.
+    await page.evaluate(() => {
+      const input = document.querySelector<HTMLInputElement>('#race-input')!
+      input.value = '0'
+      input.setSelectionRange(1, 1)
+      input.dispatchEvent(
+        new (window as unknown as { InputEvent: typeof InputEvent }).InputEvent('input', {
+          bubbles: true,
+          inputType: 'insertText',
+          data: '0',
+        }),
+      )
+    })
+
+    const state = await selectionAndValue(page)
+    expect(state.value).toBe('0')
+    expect(state.start).toBe(1)
+  })
+
+  test('navigation/shortcut keys never touch a real selection (Ctrl+A, arrows, Home/End)', async ({ page }) => {
+    await page.goto('/')
+    const keys: Array<{ key: string; ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }> = [
+      { key: 'a', ctrlKey: true },
+      { key: 'a', metaKey: true },
+      { key: 'ArrowLeft' },
+      { key: 'ArrowRight' },
+      { key: 'Home' },
+      { key: 'End' },
+      { key: 'ArrowRight', shiftKey: true },
+    ]
+    for (const init of keys) {
+      await freshMaskedInput(page, '999.999.999-99', '123.456.789-01')
+      await page.evaluate(() => document.querySelector<HTMLInputElement>('#race-input')!.setSelectionRange(3, 9))
+      await dispatchPrematureKeydown(page, init)
+      await waitAnimationFrames(page)
+      const state = await selectionAndValue(page)
+      expect(state, `key=${JSON.stringify(init)}`).toEqual({ start: 3, end: 9, value: '123.456.789-01' })
+    }
+  })
+
+  test('real keyboard end to end: select-all then fast retype always lands the correct final value', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    const input = page.locator('#phone')
+    for (let i = 0; i < 10; i++) {
+      await page.evaluate(() => {
+        const el = document.querySelector<HTMLInputElement>('#phone')!
+        el.value = '(11) 99988-7766'
+      })
+      await input.click()
+      await page.keyboard.press('Control+a')
+      await page.keyboard.type('5551234567', { delay: 0 })
+      await page.waitForTimeout(20)
+      const value = await input.inputValue()
+      const sel = await input.evaluate((el: HTMLInputElement) => el.selectionStart)
+      expect(value.replace(/\D/g, ''), `iteration ${i}`).toBe('5551234567')
+      expect(sel, `iteration ${i}`).toBe(value.length)
+    }
+  })
+})
+
+test.describe('select-and-replace race: keydown fallback frame vs. browser default action (bindDecimal)', () => {
+  test('character insert: selection is not collapsed while the edit has not landed', async ({ page }) => {
+    await page.goto('/')
+    await freshDecimalInput(page, { decimalPlaces: 2, prefix: '$' }, '$1,234.00')
+    await page.evaluate(() => document.querySelector<HTMLInputElement>('#race-input')!.setSelectionRange(0, 9))
+    await dispatchPrematureKeydown(page, { key: '5' })
+    await waitAnimationFrames(page)
+
+    const state = await selectionAndValue(page)
+    expect(state).toEqual({ start: 0, end: 9, value: '$1,234.00' })
+  })
+
+  test('Backspace: a real selection range is left untouched while the edit has not landed', async ({ page }) => {
+    await page.goto('/')
+    await freshDecimalInput(page, { decimalPlaces: 2 }, '1,234.00')
+    await page.evaluate(() => document.querySelector<HTMLInputElement>('#race-input')!.setSelectionRange(1, 5))
+    await dispatchPrematureKeydown(page, { key: 'Backspace' })
+    await waitAnimationFrames(page)
+
+    const state = await selectionAndValue(page)
+    expect(state).toEqual({ start: 1, end: 5, value: '1,234.00' })
+  })
+
+  test('real keyboard end to end: select-all then fast retype in the currency field lands the correct value', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    const input = page.locator('#usd')
+    for (let i = 0; i < 10; i++) {
+      await page.evaluate(() => {
+        const el = document.querySelector<HTMLInputElement>('#usd')!
+        el.value = '$1,234.00'
+      })
+      await input.click()
+      await page.keyboard.press('Control+a')
+      await page.keyboard.type('999', { delay: 0 })
+      await page.waitForTimeout(20)
+      const value = await input.inputValue()
+      expect(value, `iteration ${i}`).toBe('$999.00')
+    }
+  })
+})

--- a/packages/mother-mask/src/bind-decimal.ts
+++ b/packages/mother-mask/src/bind-decimal.ts
@@ -240,6 +240,7 @@ export function bindDecimal(
     const ke = e as KeyboardEvent
     const target = ke.target as HTMLInputElement
     const keyStart = getCaret(target)
+    const oldValue = target.value
 
     if (isComposing) return
 
@@ -252,6 +253,12 @@ export function bindDecimal(
     if (!(ke as { key?: string }).key) {
       lockInput = true
       scheduleFrame(() => {
+        // The browser hasn't applied this keystroke's default action yet —
+        // see the comment on the identical check below.
+        if (target.value === oldValue && target.selectionStart !== target.selectionEnd) {
+          lockInput = false
+          return
+        }
         formatCurrentValue(target)
         scheduleFrame(() => {
           lockInput = false
@@ -293,6 +300,18 @@ export function bindDecimal(
     // character insertion for this keystroke isn't guaranteed to have landed
     // yet at the point a keydown listener runs — only by the next frame.
     scheduleFrame(() => {
+      // The frame can fire before the browser has actually applied this
+      // keystroke's default action. If the selection is still a real range
+      // at that point, it's the range the user had *before* typing — not a
+      // post-edit collapsed caret — and the browser still intends to use it
+      // to replace-with-the-typed-character. Formatting now would collapse
+      // that range via `setCaret` inside `formatCurrentValue` before the
+      // pending native edit can use it, dropping or corrupting the
+      // keystroke instead of replacing the selection with it (the same
+      // Firefox race fixed in `bind.ts`). A collapsed caret (every other
+      // path/test) is unaffected by this check.
+      if (target.value === oldValue && target.selectionStart !== target.selectionEnd) return
+
       formatCurrentValue(target, {
         insertedText: isCharInsert ? ke.key : null,
         insertedAt: isCharInsert ? keyStart : undefined,

--- a/packages/mother-mask/src/bind.ts
+++ b/packages/mother-mask/src/bind.ts
@@ -222,6 +222,12 @@ export function bind(
     if (!(ke as { key?: string }).key) {
       lockInput = true
       scheduleFrame(() => {
+        // The browser hasn't applied this keystroke's default action yet —
+        // see the comment on the identical check below.
+        if (target.value === oldValue && target.selectionStart !== target.selectionEnd) {
+          lockInput = false
+          return
+        }
         const pos = target.selectionStart ?? 999
         const m = buildMask(target.value, mask, pos, { segmented })
         target.value = m.process()
@@ -255,7 +261,33 @@ export function bind(
       return
     }
 
+    // Navigation (arrows, Home/End, Tab, ...), selection, and shortcut keys
+    // (Ctrl/Cmd+A, Ctrl/Cmd+C, ...) don't change the text — leave the
+    // browser's native caret/selection handling alone instead of recomputing
+    // and overwriting it on every keystroke. Without this guard, a key like
+    // Ctrl+A schedules a reformat frame that never gets cancelled (select-all
+    // fires no `input` event), and that stray frame's `target.value =
+    // m.process()` reassignment races the browser's own pending selection —
+    // the reported Firefox bug where selecting all and retyping fast
+    // occasionally drops the caret to the start instead of replacing the
+    // selection.
+    if (!isBackspace && !isDelete && !isCharInsert && !isUnidentified) return
+
     scheduleFrame(() => {
+      // The scheduled frame can fire before the browser has actually applied
+      // this keystroke's default action (confirmed via real-Firefox
+      // tracing: `target.value` is still unchanged here). If the selection
+      // is still a real range at that point, it's the range the user had
+      // *before* typing — not a post-edit collapsed caret — and the browser
+      // still intends to use it to replace-with-the-typed-character. Calling
+      // `setSelectionRange` below would collapse that range out from under
+      // the pending native edit, so the character gets inserted at the
+      // collapsed point instead of replacing the selection (or dropped
+      // entirely). Bail and let the authoritative `input` handler take over
+      // once the edit actually lands — a collapsed caret (the case every
+      // other test/path exercises) is unaffected by this check.
+      if (target.value === oldValue && target.selectionStart !== target.selectionEnd) return
+
       const pos = target.selectionStart ?? 999
       const m = buildMask(target.value, mask, pos, { segmented })
       target.value = m.process()

--- a/packages/mother-mask/tests/bind-decimal.test.ts
+++ b/packages/mother-mask/tests/bind-decimal.test.ts
@@ -464,6 +464,185 @@ describe('bindDecimal() — event handlers', () => {
   })
 })
 
+describe('bindDecimal() — select-and-replace race (keydown fallback frame vs. browser default action)', () => {
+  // Same real-Firefox race fixed in `bind.ts`: the `keydown` +
+  // `requestAnimationFrame` fallback frame can fire before the browser has
+  // actually applied the keystroke's default action. If the selection is
+  // still a real (non-collapsed) range at that point and the value hasn't
+  // changed yet, formatting must not run — `formatCurrentValue` ends in
+  // `setCaret`, which would collapse the range the browser's own pending
+  // replace-selection edit still needs.
+  let input: HTMLInputElement
+
+  beforeEach(() => {
+    input = document.createElement('input')
+    document.body.appendChild(input)
+  })
+
+  afterEach(() => {
+    input.remove()
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('character insert: does not collapse the selection when the frame fires before the edit lands', async () => {
+    const { bindDecimal } = await import('../src/index')
+    const cb = vi.fn()
+    bindDecimal(input, { decimalPlaces: 2, prefix: '$', onChange: cb })
+    input.value = '$1,234.00'
+    input.setSelectionRange(0, 9) // full selection
+    dispatchKey(input, '5')
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(9)
+    expect(input.value).toBe('$1,234.00')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('Backspace: does not collapse a real selection when the frame fires before the edit lands', async () => {
+    const { bindDecimal } = await import('../src/index')
+    const cb = vi.fn()
+    bindDecimal(input, { decimalPlaces: 2, onChange: cb })
+    input.value = '1,234.00'
+    input.setSelectionRange(1, 5) // ",234" selected
+    dispatchKey(input, 'Backspace')
+    await flushRafs()
+    expect(input.selectionStart).toBe(1)
+    expect(input.selectionEnd).toBe(5)
+    expect(input.value).toBe('1,234.00')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('Delete: does not collapse a real selection when the frame fires before the edit lands', async () => {
+    const { bindDecimal } = await import('../src/index')
+    const cb = vi.fn()
+    bindDecimal(input, { decimalPlaces: 2, onChange: cb })
+    input.value = '1,234.00'
+    input.setSelectionRange(2, 6)
+    dispatchKey(input, 'Delete')
+    await flushRafs()
+    expect(input.selectionStart).toBe(2)
+    expect(input.selectionEnd).toBe(6)
+    expect(input.value).toBe('1,234.00')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('Android missing-key path: does not collapse a real selection and releases lockInput when the edit has not landed', async () => {
+    const { bindDecimal } = await import('../src/index')
+    const cb = vi.fn()
+    bindDecimal(input, { decimalPlaces: 2, onChange: cb })
+    input.value = '1,234.00'
+    input.setSelectionRange(0, 8)
+    const ev = new KeyboardEvent('keydown', { bubbles: true, cancelable: true })
+    Object.defineProperty(ev, 'key', { value: undefined, configurable: true })
+    input.dispatchEvent(ev)
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(8)
+    expect(input.value).toBe('1,234.00')
+    expect(cb).not.toHaveBeenCalled()
+
+    // Bailing must still release `lockInput` for the next keystroke.
+    input.value = '5'
+    input.setSelectionRange(1, 1)
+    const next = new KeyboardEvent('keydown', { key: '5', bubbles: true, cancelable: true })
+    input.dispatchEvent(next)
+    expect(next.defaultPrevented).toBe(false)
+    await flushRafs()
+    expect(cb).toHaveBeenCalled()
+  })
+
+  it('does not bail when the selection is already collapsed (the common, always-tested case)', async () => {
+    const { bindDecimal } = await import('../src/index')
+    const cb = vi.fn()
+    bindDecimal(input, { decimalPlaces: 2, onChange: cb })
+    input.value = '5'
+    input.setSelectionRange(1, 1)
+    dispatchKey(input, '5')
+    await flushRafs()
+    expect(cb).toHaveBeenCalled()
+  })
+
+  it('does not bail when the value has already changed, even if the resulting selection happens to be a range', async () => {
+    const { bindDecimal } = await import('../src/index')
+    const cb = vi.fn()
+    bindDecimal(input, { decimalPlaces: 2, onChange: cb })
+    input.value = '1,234.00'
+    input.setSelectionRange(0, 8)
+    dispatchKey(input, '9')
+    // Simulate the browser landing on a different value than oldValue while
+    // leaving a non-collapsed selection.
+    input.value = '9,999.00'
+    input.setSelectionRange(0, 1)
+    await flushRafs()
+    expect(cb).toHaveBeenCalled()
+  })
+
+  it('recovers correctly once the browser applies the edit and fires `input`, even after the fallback frame bailed', async () => {
+    const { bindDecimal } = await import('../src/index')
+    const cb = vi.fn()
+    bindDecimal(input, { decimalPlaces: 2, prefix: '$', onChange: cb })
+    input.value = '$1,234.00'
+    input.setSelectionRange(0, 9)
+    dispatchKey(input, '5')
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(9)
+
+    input.value = '5'
+    input.setSelectionRange(1, 1)
+    dispatchInput(input, { data: '5', inputType: 'insertText' })
+
+    expect(input.value).toBe('$5.00')
+    expect(cb).toHaveBeenCalledWith('$5.00', 5)
+  })
+})
+
+describe('bindDecimal() — navigation and shortcut keys never schedule a reformat', () => {
+  let input: HTMLInputElement
+
+  beforeEach(() => {
+    input = document.createElement('input')
+    document.body.appendChild(input)
+  })
+
+  afterEach(() => {
+    input.remove()
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  const cases: Array<{ name: string; init: () => KeyboardEventInit }> = [
+    { name: 'Ctrl+A', init: () => ({ key: 'a', ctrlKey: true }) },
+    { name: 'Cmd+A (Meta)', init: () => ({ key: 'a', metaKey: true }) },
+    { name: 'Ctrl+C', init: () => ({ key: 'c', ctrlKey: true }) },
+    { name: 'ArrowLeft', init: () => ({ key: 'ArrowLeft' }) },
+    { name: 'ArrowRight', init: () => ({ key: 'ArrowRight' }) },
+    { name: 'Home', init: () => ({ key: 'Home' }) },
+    { name: 'End', init: () => ({ key: 'End' }) },
+    { name: 'Tab', init: () => ({ key: 'Tab' }) },
+    { name: 'Shift+ArrowRight', init: () => ({ key: 'ArrowRight', shiftKey: true }) },
+  ]
+
+  for (const { name, init } of cases) {
+    it(`${name}: leaves value, selection, and onChange untouched`, async () => {
+      const { bindDecimal } = await import('../src/index')
+      const cb = vi.fn()
+      bindDecimal(input, { decimalPlaces: 2, prefix: '$', onChange: cb })
+      input.value = '$1,234.00'
+      input.setSelectionRange(2, 6)
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { ...init(), bubbles: true, cancelable: true }),
+      )
+      await flushRafs()
+      expect(input.value).toBe('$1,234.00')
+      expect(input.selectionStart).toBe(2)
+      expect(input.selectionEnd).toBe(6)
+      expect(cb).not.toHaveBeenCalled()
+    })
+  }
+})
+
 describe('bindDecimal() — caret / selection', () => {
   let input: HTMLInputElement
 

--- a/packages/mother-mask/tests/bind.test.ts
+++ b/packages/mother-mask/tests/bind.test.ts
@@ -149,33 +149,6 @@ describe('bind() — event handlers', () => {
     expect(input.value).toBe('12')
   })
 
-  it('does not collapse a real selection range if the keydown fallback frame fires before the browser applies the edit', async () => {
-    // Regression test for a real-Firefox race, captured via tracing: select
-    // all, then type a character over a full field. The keydown+rAF
-    // fallback frame can fire *before* Firefox has actually replaced the
-    // selection with the typed character — at that point `target.value` is
-    // still unchanged and the selection is still the full pre-edit range.
-    // The old code blindly reformatted and called `setSelectionRange`,
-    // collapsing that range to a single point before the browser's own
-    // pending replace-selection edit could use it — dropping or corrupting
-    // the keystroke instead of replacing the selection.
-    const { bind } = await import('../src/index')
-    const cb = vi.fn()
-    bind(input, '999.999.999-99', cb)
-    input.value = '098.098.098-08'
-    input.setSelectionRange(0, 14)
-    input.dispatchEvent(
-      new KeyboardEvent('keydown', { key: '0', bubbles: true, cancelable: true }),
-    )
-    // No `input` event dispatched — simulating the browser not having
-    // applied the edit yet by the time the fallback frame fires.
-    await flushRafs()
-    expect(input.selectionStart).toBe(0)
-    expect(input.selectionEnd).toBe(14)
-    expect(input.value).toBe('098.098.098-08')
-    expect(cb).not.toHaveBeenCalled()
-  })
-
   it('handles keydown with missing key (Android WebView style)', async () => {
     const { bind } = await import('../src/index')
     bind(input, '99')
@@ -259,6 +232,311 @@ describe('bind() — event handlers', () => {
     input.dispatchEvent(new Event('paste', { bubbles: true }))
     await flushRafs(1)
     expect(input.value).toBe('1A.B2C.3D4/5E6F-78')
+  })
+})
+
+describe('bind() — select-and-replace race (keydown fallback frame vs. browser default action)', () => {
+  // Regression coverage for a real-Firefox bug, captured via tracing: select
+  // all text in a full field, then type over it. The `keydown` +
+  // `requestAnimationFrame` fallback frame can fire *before* Firefox has
+  // actually applied the keystroke's default action — at that point
+  // `target.value` is still unchanged and the selection is still the full
+  // pre-edit range, not a post-edit collapsed caret. The old code blindly
+  // reformatted and called `setSelectionRange`/`setCaret`, collapsing that
+  // range before the browser's own pending replace-selection edit could use
+  // it, so the character got inserted at the now-collapsed point instead of
+  // replacing the selection (or was dropped entirely).
+  //
+  // Every test below simulates the race by dispatching only `keydown` (never
+  // `input`) with the selection still spanning a real range and the value
+  // still at its pre-keystroke content — exactly what a premature frame
+  // observes in the real bug.
+  let input: HTMLInputElement
+
+  beforeEach(() => {
+    input = document.createElement('input')
+    document.body.appendChild(input)
+  })
+
+  afterEach(() => {
+    input.remove()
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('character insert: does not collapse the selection when the frame fires before the edit lands', async () => {
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999.999.999-99', cb)
+    input.value = '098.098.098-08'
+    input.setSelectionRange(0, 14)
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: '0', bubbles: true, cancelable: true }),
+    )
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(14)
+    expect(input.value).toBe('098.098.098-08')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('Backspace: does not collapse a real selection when the frame fires before the edit lands', async () => {
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999-999', cb)
+    input.value = '123-456'
+    input.setSelectionRange(1, 5) // "23-4" selected
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }),
+    )
+    await flushRafs()
+    expect(input.selectionStart).toBe(1)
+    expect(input.selectionEnd).toBe(5)
+    expect(input.value).toBe('123-456')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('Delete: does not collapse a real selection when the frame fires before the edit lands', async () => {
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999-999', cb)
+    input.value = '123-456'
+    input.setSelectionRange(2, 6) // "3-45" selected
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Delete', bubbles: true, cancelable: true }),
+    )
+    await flushRafs()
+    expect(input.selectionStart).toBe(2)
+    expect(input.selectionEnd).toBe(6)
+    expect(input.value).toBe('123-456')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('Unidentified key: does not collapse a real selection when the frame fires before the edit lands', async () => {
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999-999', cb)
+    input.value = '123-456'
+    input.setSelectionRange(0, 7) // full selection
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Unidentified', bubbles: true, cancelable: true }),
+    )
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(7)
+    expect(input.value).toBe('123-456')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('Android missing-key path: does not collapse a real selection and releases lockInput when the edit has not landed', async () => {
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999-999', cb)
+    input.value = '123-456'
+    input.setSelectionRange(0, 7)
+    const ev = new KeyboardEvent('keydown', { bubbles: true, cancelable: true })
+    Object.defineProperty(ev, 'key', { value: undefined, configurable: true })
+    input.dispatchEvent(ev)
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(7)
+    expect(input.value).toBe('123-456')
+    expect(cb).not.toHaveBeenCalled()
+
+    // Bailing must still release `lockInput` — a normal keystroke right
+    // after must not be blocked forever by the abandoned async path.
+    input.value = '1'
+    input.setSelectionRange(1, 1)
+    const next = new KeyboardEvent('keydown', { key: '1', bubbles: true, cancelable: true })
+    input.dispatchEvent(next)
+    expect(next.defaultPrevented).toBe(false)
+    await flushRafs()
+    expect(cb).toHaveBeenCalled()
+  })
+
+  it('does not bail when the selection is already collapsed, even if the value looks unchanged (the common, always-tested case)', async () => {
+    // Every other test in this file pre-sets `input.value` to the "already
+    // edited" state before dispatching keydown, so `oldValue` captured
+    // inside `onKey` already equals what the frame later reads — i.e.
+    // `target.value === oldValue` is true by construction. This must NOT
+    // bail, because the selection is collapsed (a real post-edit caret, not
+    // a pre-edit range), which is the ordinary, extensively-tested path.
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999', cb)
+    input.value = '5'
+    input.setSelectionRange(1, 1)
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: '5', bubbles: true, cancelable: true }),
+    )
+    await flushRafs()
+    expect(cb).toHaveBeenCalledWith('5')
+  })
+
+  it('does not bail when the value has already changed, even if the resulting selection happens to be a range', async () => {
+    // The bail condition requires BOTH "value unchanged" AND "selection is a
+    // real range" — if the value differs from `oldValue`, the edit has
+    // landed, and formatting must proceed regardless of what the selection
+    // looks like at frame time.
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999-999', cb)
+    input.value = '123-456'
+    input.setSelectionRange(0, 7)
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: '9', bubbles: true, cancelable: true }),
+    )
+    // Simulate the browser having applied a *different* edit than the one
+    // read at keydown time (e.g. autocorrect/IME), landing on a value that
+    // differs from oldValue, but leaving a non-collapsed selection.
+    input.value = '999-456'
+    input.setSelectionRange(0, 3)
+    await flushRafs()
+    expect(cb).toHaveBeenCalled()
+  })
+
+  it('recovers correctly once the browser applies the edit and fires `input`, even after the fallback frame bailed', async () => {
+    // End-to-end version of the real bug's full lifecycle: the fallback
+    // frame observes the edit hasn't landed and bails (selection preserved);
+    // the browser then actually applies the edit slightly late and fires the
+    // authoritative `input` event, which must still format correctly.
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999.999.999-99', cb)
+    input.value = '098.098.098-08'
+    input.setSelectionRange(0, 14)
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: '0', bubbles: true, cancelable: true }),
+    )
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(14)
+
+    // Browser now applies the real edit: selection replaced with '0'.
+    input.value = '0'
+    input.setSelectionRange(1, 1)
+    input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: '0' }))
+
+    expect(input.value).toBe('0')
+    expect(input.selectionStart).toBe(1)
+    expect(cb).toHaveBeenCalledWith('0')
+  })
+
+  it('fast typing into a full field after select-all: every keystroke lands and the final value is correct', async () => {
+    // Realistic end-to-end repro: select-all over a full CPF, then type the
+    // whole new number. Some keydowns' fallback frames race the (never
+    // dispatched, in this synchronous test) browser mutation and bail; the
+    // real `input` events — dispatched here to simulate the browser
+    // eventually catching up — are what actually drive the formatting, and
+    // must produce the correct final result regardless of what the bailed
+    // frames did or didn't touch.
+    const { bind } = await import('../src/index')
+    bind(input, '999.999.999-99')
+    input.value = '098.098.098-08'
+    input.setSelectionRange(0, 14)
+
+    const digits = '11122233344'
+    let raw = ''
+    for (const digit of digits) {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: digit, bubbles: true, cancelable: true }),
+      )
+      // Browser applies the keystroke and fires `input` before the next one.
+      raw = raw === '' ? digit : input.value.replace(/[^0-9]/g, '') + digit
+      const pos = raw.length
+      input.value = raw
+      input.setSelectionRange(pos, pos)
+      input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: digit }))
+    }
+    await flushRafs()
+    expect(input.value).toBe('111.222.333-44')
+    expect(input.selectionStart).toBe(14)
+  })
+})
+
+describe('bind() — navigation and shortcut keys never schedule a reformat', () => {
+  // Ctrl/Cmd+A, arrows, Home/End, Tab, etc. don't edit text. Scheduling a
+  // reformat frame for them anyway was the other half of the real-Firefox
+  // bug: Ctrl+A's own keydown scheduled a frame that's never cancelled
+  // (select-all fires no `input` event), and that frame's blind
+  // `setSelectionRange` call could stomp on the selection the user just
+  // made. None of these keys should touch the value, the selection, or
+  // invoke `onChange`.
+  let input: HTMLInputElement
+
+  beforeEach(() => {
+    input = document.createElement('input')
+    document.body.appendChild(input)
+  })
+
+  afterEach(() => {
+    input.remove()
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  const cases: Array<{ name: string; init: () => KeyboardEventInit }> = [
+    { name: 'Ctrl+A', init: () => ({ key: 'a', ctrlKey: true }) },
+    { name: 'Cmd+A (Meta)', init: () => ({ key: 'a', metaKey: true }) },
+    { name: 'Ctrl+C', init: () => ({ key: 'c', ctrlKey: true }) },
+    { name: 'ArrowLeft', init: () => ({ key: 'ArrowLeft' }) },
+    { name: 'ArrowRight', init: () => ({ key: 'ArrowRight' }) },
+    { name: 'ArrowUp', init: () => ({ key: 'ArrowUp' }) },
+    { name: 'ArrowDown', init: () => ({ key: 'ArrowDown' }) },
+    { name: 'Home', init: () => ({ key: 'Home' }) },
+    { name: 'End', init: () => ({ key: 'End' }) },
+    { name: 'Tab', init: () => ({ key: 'Tab' }) },
+    { name: 'Escape', init: () => ({ key: 'Escape' }) },
+    { name: 'Shift+ArrowRight', init: () => ({ key: 'ArrowRight', shiftKey: true }) },
+    { name: 'Shift+Home', init: () => ({ key: 'Home', shiftKey: true }) },
+    { name: 'Shift+End', init: () => ({ key: 'End', shiftKey: true }) },
+    { name: 'Alt+ArrowLeft', init: () => ({ key: 'ArrowLeft', altKey: true }) },
+  ]
+
+  for (const { name, init } of cases) {
+    it(`${name}: leaves value, selection, and onChange untouched`, async () => {
+      const { bind } = await import('../src/index')
+      const cb = vi.fn()
+      bind(input, '999.999.999-99', cb)
+      input.value = '123.456.789-01'
+      input.setSelectionRange(3, 9) // a real, arbitrary selection
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { ...init(), bubbles: true, cancelable: true }),
+      )
+      await flushRafs()
+      expect(input.value).toBe('123.456.789-01')
+      expect(input.selectionStart).toBe(3)
+      expect(input.selectionEnd).toBe(9)
+      expect(cb).not.toHaveBeenCalled()
+    })
+  }
+
+  it('Ctrl+A immediately followed by a real character keydown: only the character keydown schedules a frame', async () => {
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999.999.999-99', cb)
+    input.value = '098.098.098-08'
+    input.setSelectionRange(0, 14)
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, bubbles: true, cancelable: true }),
+    )
+    // Ctrl+A must not have disturbed anything on its own.
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(14)
+    expect(input.value).toBe('098.098.098-08')
+    expect(cb).not.toHaveBeenCalled()
+
+    // Now the actual retype: still selected, browser hasn't applied it yet.
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: '0', bubbles: true, cancelable: true }),
+    )
+    await flushRafs()
+    // Selection must still be intact — untouched by either keydown.
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(14)
+    expect(cb).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/mother-mask/tests/bind.test.ts
+++ b/packages/mother-mask/tests/bind.test.ts
@@ -149,6 +149,33 @@ describe('bind() — event handlers', () => {
     expect(input.value).toBe('12')
   })
 
+  it('does not collapse a real selection range if the keydown fallback frame fires before the browser applies the edit', async () => {
+    // Regression test for a real-Firefox race, captured via tracing: select
+    // all, then type a character over a full field. The keydown+rAF
+    // fallback frame can fire *before* Firefox has actually replaced the
+    // selection with the typed character — at that point `target.value` is
+    // still unchanged and the selection is still the full pre-edit range.
+    // The old code blindly reformatted and called `setSelectionRange`,
+    // collapsing that range to a single point before the browser's own
+    // pending replace-selection edit could use it — dropping or corrupting
+    // the keystroke instead of replacing the selection.
+    const { bind } = await import('../src/index')
+    const cb = vi.fn()
+    bind(input, '999.999.999-99', cb)
+    input.value = '098.098.098-08'
+    input.setSelectionRange(0, 14)
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: '0', bubbles: true, cancelable: true }),
+    )
+    // No `input` event dispatched — simulating the browser not having
+    // applied the edit yet by the time the fallback frame fires.
+    await flushRafs()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(14)
+    expect(input.value).toBe('098.098.098-08')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
   it('handles keydown with missing key (Android WebView style)', async () => {
     const { bind } = await import('../src/index')
     bind(input, '99')


### PR DESCRIPTION
This pull request addresses a subtle race condition in masked input handling, especially in Firefox, where a scheduled reformat frame could interfere with the browser's native select-and-replace behavior—leading to dropped or corrupted keystrokes when quickly replacing a selection. The fix ensures that formatting and caret manipulation are deferred until after the browser has applied the user's edit, preserving the selection and preventing data loss. The changes also add comprehensive regression tests (including Playwright E2E and unit tests) to prevent this bug from recurring.

### Race condition fix for masked inputs

* Updated `bind` and `bindDecimal` in `bind.ts` and `bind-decimal.ts` to bail out of scheduled formatting if the browser hasn't yet applied the keystroke and the selection is still a range, preventing premature caret collapse and dropped keystrokes. [[1]](diffhunk://#diff-2e5a7db126219e0148ffd382d35f90dba69f2f684e5db8014625ec07a7315933R225-R230) [[2]](diffhunk://#diff-2e5a7db126219e0148ffd382d35f90dba69f2f684e5db8014625ec07a7315933R264-R290) [[3]](diffhunk://#diff-9323584233b2025b15bca86a028af7337375fe346fe906168ffa5512ef81e722R243) [[4]](diffhunk://#diff-9323584233b2025b15bca86a028af7337375fe346fe906168ffa5512ef81e722R256-R261) [[5]](diffhunk://#diff-9323584233b2025b15bca86a028af7337375fe346fe906168ffa5512ef81e722R303-R314)

### Regression and E2E tests

* Added a new Playwright E2E test suite (`select-replace-race.spec.ts`) that deterministically reproduces and verifies the select-and-replace race condition, including real keyboard scenarios, and ensures the fix works across both `bind` and `bindDecimal`.
* Added a dedicated Firefox test configuration and npm script to ensure this race is tested in the original problematic browser. [[1]](diffhunk://#diff-a02b008b50077ce0795c0dee89c3b663ead543e6d790874baece325aee7f1043R9) [[2]](diffhunk://#diff-17aff460b7daab695c1cd733aa91b0b69635d6cbbb1c1ecf96775e892f5f39a9R1-R18)

### Unit tests

* Added thorough unit tests to `bind-decimal.test.ts` to cover all edge cases of the race condition, navigation/shortcut keys, and proper recovery after edits, ensuring the fix is robust and does not introduce regressions.

These changes collectively harden the input masking library against a tricky cross-browser timing bug and provide strong test coverage to prevent regressions.